### PR TITLE
Generate uuid for tracked object id 

### DIFF
--- a/norfair/tracker.py
+++ b/norfair/tracker.py
@@ -1,4 +1,5 @@
 import math
+import uuid
 from typing import Callable, List, Optional, Sequence
 
 import numpy as np
@@ -235,7 +236,7 @@ class TrackedObject:
         self.last_detection: "Detection" = initial_detection
         self.age: int = 0
         self.is_initializing_flag: bool = True
-        self.id: Optional[int] = None
+        self.id: Optional[str] = None
         self.initializing_id: int = (
             TrackedObject.initializing_count
         )  # Just for debugging
@@ -267,7 +268,7 @@ class TrackedObject:
         ):
             self.is_initializing_flag = False
             TrackedObject.count += 1
-            self.id = TrackedObject.count
+            self.id = str(uuid.uuidv4())
         return self.is_initializing_flag
 
     @property


### PR DESCRIPTION
# Description

Generate uuid for tracked object instead of count. This will provide consistency when deploy apps in a volatile environment when service can be down but object still need to be tracked.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules